### PR TITLE
Fix:(excel_processor.py):csv文件类型在parse入参为str/Path的情况下解析出错的问题;

### DIFF
--- a/excel_processor.py
+++ b/excel_processor.py
@@ -49,7 +49,7 @@ class ExcelParser:
         支持文件路径,Path,文件的bytes以及BytesIO
         """
         if isinstance(input_data, (str, Path)):
-            path = Path(input_data)
+            path = Path(input_data) if isinstance(input_data, str) else input_data
             if not path.exists():
                 raise FileNotFoundError(f'{path} is not exists.')
             if not path.is_file():
@@ -63,7 +63,15 @@ class ExcelParser:
         else:
             raise TypeError(f'{input_data} is not a valid type. 输入类型必须是路径、bytes 或 BytesIO')
 
-        file_type = xlrd.inspect_format(content=file_bytes)
+        try:
+            if isinstance(input_data, str) and input_data.endswith('.csv'):
+                file_type = 'csv'
+            elif isinstance(path, Path) and path.suffix == '.csv':
+                file_type = 'csv'
+            else:
+                file_type = xlrd.inspect_format(content=file_bytes)
+        except Exception:
+            raise ValueError('无法解析文件，未知格式，当前只支持.xls/.xlsx/.csv格式')
 
         parsers = {
             'xls': (self.parse_xlrd, xlrd.biffh.XLRDError, "无法解析 .xls 文件，可能已损坏"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandas==2.2.3
 python_docx==1.1.2
 rich==14.0.0
 xlrd==2.0.1
+traits==7.0.2


### PR DESCRIPTION
fix:parse传入str、Path区分path变量初始化；
fix:parse传入str、Path变量时，csv文件类型通过后缀获取，仅通过inspect_format无法取得csv文件类型;